### PR TITLE
fix(types): resolve mypy typing errors in sast_scanner

### DIFF
--- a/src/domain/sast_scanner.py
+++ b/src/domain/sast_scanner.py
@@ -14,7 +14,7 @@ class SASTScanner:
         self.mode = "strict"
         self._load_profile()
 
-    def _load_profile(self):
+    def _load_profile(self) -> None:
         try:
             with open(self.profile_path, encoding="utf-8") as f:
                 profile = json.load(f)
@@ -44,7 +44,7 @@ class SASTScanner:
 
             print(f"[SAST WARNING] Potential {rule} at `{path}:{line_no}`.")
             print(f"- Severity: {severity}")
-            print(f"- Line: `{ctx['line_content'].strip()}`")
+            print(f"- Line: `{str(ctx['line_content']).strip()}`")
             print(f"- Scope: `{ctx['scope']}`")
 
             if self.mode == "draft" and severity in ("MEDIUM", "LOW"):


### PR DESCRIPTION
Fixes 3 Mypy typing errors in `src/domain/sast_scanner.py`:

- Added `-> None` return type annotation to `_load_profile(self)` to resolve `[no-untyped-def]` and `[no-untyped-call]`
- Coerced `ctx['line_content']` to `str` before calling `.strip()` to fix the `Item "bool" of "str | bool" has no attribute "strip" [union-attr]` error

Mypy now passes with 0 errors across 11 source files.
Please review and merge.