### PR TITLE
fix(ci): comprehensively resolve pylint and mypy errors across codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Pylint Analysis
         run: |
-          python -m pylint control_plane.py hooks/run_audit_hook.py hooks/run_firewall_hook.py scripts/md_to_json.py src/ tests/
+          python -m pylint control_plane.py hooks/run_audit_hook.py scripts/md_to_json.py src/ tests/
 
       - name: Run Mypy Type Checker
         run: |

--- a/src/domain/context_extractor.py
+++ b/src/domain/context_extractor.py
@@ -36,7 +36,7 @@ def extract_context(file_path: str, line_number: int) -> dict[str, str | bool]:
                     if t.type in (tokenize.COMMENT, tokenize.STRING):
                         is_safe_context = True
                         break
-                    elif t.type not in (
+                    if t.type not in (
                         tokenize.NL,
                         tokenize.NEWLINE,
                         tokenize.INDENT,

--- a/src/domain/sast_scanner.py
+++ b/src/domain/sast_scanner.py
@@ -14,7 +14,7 @@ class SASTScanner:
         self.mode = "strict"
         self._load_profile()
 
-    def _load_profile(self):
+    def _load_profile(self) -> None:
         try:
             with open(self.profile_path, encoding="utf-8") as f:
                 profile = json.load(f)
@@ -44,7 +44,7 @@ class SASTScanner:
 
             print(f"[SAST WARNING] Potential {rule} at `{path}:{line_no}`.")
             print(f"- Severity: {severity}")
-            print(f"- Line: `{ctx['line_content'].strip()}`")
+            print(f"- Line: `{str(ctx['line_content']).strip()}`")
             print(f"- Scope: `{ctx['scope']}`")
 
             if self.mode == "draft" and severity in ("MEDIUM", "LOW"):


### PR DESCRIPTION
This PR combines and supersedes the previous fixes to ensure all CI checks pass flawlessly.

Includes:
1. `ci.yml`: Removes the deleted `hooks/run_firewall_hook.py` file from the hardcoded `pylint` command path list to resolve the "fatal: no module found" error.
2. `src/domain/context_extractor.py`: Replaces the unnecessary `elif` with `if` (Line 36) to fix the `[no-else-break]` `R1723` pylint warning. 
3. `src/domain/sast_scanner.py`: 
   - Specifies `-> None` return type for `_load_profile` to resolve mypy's `[no-untyped-def]` and `[no-untyped-call]`.
   - Safely coerces `ctx['line_content']` to `str()` before applying `.strip()` to resolve mypy's `[union-attr]` complaining about bools having no attribute strip.

**Tests Executed Successfully:**
- `python -m ruff check .` (0 errors)
- `python -m ruff format --check .` (0 errors)
- `python -m mypy ...` (Success: no issues)
- `python -m pylint ...` (Rated 10.00/10)
- `python -m pytest` (100% Passed)

Please review and merge.