### PR TITLE
fix(release-please): migrate config to v4 schema

### DIFF
--- a/docs/superpowers/plans/2026-08-04-release-please-v4-migration-plan.md
+++ b/docs/superpowers/plans/2026-08-04-release-please-v4-migration-plan.md
@@ -1,0 +1,69 @@
+# Release Please v4 Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Khắc phục lỗi `release-please` không tạo Pull Request bằng cách bọc toàn bộ file cấu hình vào trong block `"packages": { ".": { ... } }` theo chuẩn schema v4.
+
+**Architecture:** Nâng cấp cấu hình từ cấu trúc v3 sang v4, khai báo explicitly đường dẫn root `.` bên trong object `packages` để `release-please-action@v4` nhận diện chính xác ứng dụng cần release.
+
+**Tech Stack:** JSON, GitHub Actions.
+
+## Global Constraints
+
+- File `release-please-config.json` phải hợp lệ định dạng JSON.
+- Cấu hình phải tuân thủ chuẩn schema `https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json`.
+- Commit thông báo phải chuẩn Conventional Commits có dạng `fix: migrate release-please to v4`.
+
+---
+
+### Task 1: Update release-please-config.json
+
+**Files:**
+- Modify: `release-please-config.json`
+
+**Interfaces:**
+- Consumes: N/A
+- Produces: Cấu hình chuẩn v4 để bot sinh PR thành công.
+
+- [ ] **Step 1: Write the updated configuration to `release-please-config.json`**
+
+Thay thế toàn bộ nội dung file `release-please-config.json` bằng đoạn JSON sau:
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {
+      "release-type": "python",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
+        }
+      ],
+      "changelog-sections": [
+        { "type": "feat", "section": "🚀 Features & SAST Security Rules", "hidden": false },
+        { "type": "fix", "section": "🐛 Bug Fixes", "hidden": false },
+        { "type": "perf", "section": "⚡ Performance Improvements", "hidden": false },
+        { "type": "refactor", "section": "♻️ Refactoring & Code Hygiene", "hidden": false },
+        { "type": "build", "section": "📦 Build System & Dependencies", "hidden": false },
+        { "type": "ci", "section": "🤖 CI/CD Workflows", "hidden": false },
+        { "type": "docs", "section": "📝 Documentation", "hidden": false },
+        { "type": "style", "section": "🎨 Code Style & Formatting", "hidden": false }
+      ]
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Check JSON validity**
+
+Run: `node -e "require('./release-please-config.json')"` (hoặc dùng jq `jq . release-please-config.json`)
+Expected: Không hiện ra lỗi (Valid JSON).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add release-please-config.json
+git commit -m "fix: migrate release-please config to v4 schema"
+```

--- a/docs/superpowers/specs/2026-08-04-release-please-v4-migration-design.md
+++ b/docs/superpowers/specs/2026-08-04-release-please-v4-migration-design.md
@@ -1,0 +1,51 @@
+# Release Please v4 Migration Design
+
+## Purpose
+Khắc phục lỗi GitHub Action `release-please` chạy thành công (Success) nhưng không sinh ra Pull Request mới. 
+Nguyên nhân gốc là dự án đang sử dụng `release-please-action@v4` kết hợp với chuẩn cấu hình cũ (v3) không có wrapper `"packages"`.
+
+## Scope
+Chỉ tập trung vào 2 file:
+1. `release-please-config.json`: Cấu trúc lại dữ liệu sang schema v4.
+2. `.github/workflows/release.yml`: Khắc phục cảnh báo "Node.js 20 is deprecated" bằng cách nâng cấp version Node.js của action nếu cần (hoặc update các setup actions).
+
+## Architecture / Config Design
+
+### `release-please-config.json`
+Đưa tất cả cấu hình (`release-type`, `extra-files`, `changelog-sections`) vào trong một key `packages` với key con là `.` (đại diện cho thư mục root của dự án - simple repo mode).
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {
+      "release-type": "python",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
+        }
+      ],
+      "changelog-sections": [
+        { "type": "feat", "section": "🚀 Features & SAST Security Rules", "hidden": false },
+        { "type": "fix", "section": "🐛 Bug Fixes", "hidden": false },
+        { "type": "perf", "section": "⚡ Performance Improvements", "hidden": false },
+        { "type": "refactor", "section": "♻️ Refactoring & Code Hygiene", "hidden": false },
+        { "type": "build", "section": "📦 Build System & Dependencies", "hidden": false },
+        { "type": "ci", "section": "🤖 CI/CD Workflows", "hidden": false },
+        { "type": "docs", "section": "📝 Documentation", "hidden": false },
+        { "type": "style", "section": "🎨 Code Style & Formatting", "hidden": false }
+      ]
+    }
+  }
+}
+```
+
+### `.github/workflows/release.yml`
+Sử dụng node20 chuẩn hoặc nâng cấp action (thực tế `googleapis/release-please-action@v4` mặc định chạy trên node20, việc GitHub ép lên node24 chỉ là warning, không gây lỗi hệ thống. Ta sẽ cập nhật action lên bản mới nhất nếu có để hạn chế warning).
+
+## Testing Strategy
+- Sau khi áp dụng thay đổi, push trực tiếp một commit kiểu `fix: migrate release-please to v4` lên `main`.
+- Quan sát luồng `Release Please PR Automation` trong GitHub Actions.
+- Kết quả mong đợi (Success Criteria): Bot sẽ tự động tạo một Pull Request có tiêu đề `chore(main): release 0.1.1`.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,21 +1,26 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "python",
-  "extra-files": [
-    {
-      "type": "json",
-      "path": "plugin.json",
-      "jsonpath": "$.version"
+  "packages": {
+    ".": {
+      "release-type": "python",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
+        }
+      ],
+      "changelog-sections": [
+        { "type": "feat", "section": "🚀 Features & SAST Security Rules", "hidden": false },
+        { "type": "fix", "section": "🐛 Bug Fixes", "hidden": false },
+        { "type": "perf", "section": "⚡ Performance Improvements", "hidden": false },
+        { "type": "refactor", "section": "♻️ Refactoring & Code Hygiene", "hidden": false },
+        { "type": "build", "section": "📦 Build System & Dependencies", "hidden": false },
+        { "type": "ci", "section": "🤖 CI/CD Workflows", "hidden": false },
+        { "type": "docs", "section": "📝 Documentation", "hidden": false },
+        { "type": "style", "section": "🎨 Code Style & Formatting", "hidden": false }
+      ]
     }
-  ],
-  "changelog-sections": [
-    { "type": "feat", "section": "🚀 Features & SAST Security Rules", "hidden": false },
-    { "type": "fix", "section": "🐛 Bug Fixes", "hidden": false },
-    { "type": "perf", "section": "⚡ Performance Improvements", "hidden": false },
-    { "type": "refactor", "section": "♻️ Refactoring & Code Hygiene", "hidden": false },
-    { "type": "build", "section": "📦 Build System & Dependencies", "hidden": false },
-    { "type": "ci", "section": "🤖 CI/CD Workflows", "hidden": false },
-    { "type": "docs", "section": "📝 Documentation", "hidden": false },
-    { "type": "style", "section": "🎨 Code Style & Formatting", "hidden": false }
-  ]
+  }
 }
+


### PR DESCRIPTION
This PR migrates the release-please configuration from v3 schema to v4 schema by wrapping the settings in a `packages` block. This ensures that the `googleapis/release-please-action@v4` action correctly identifies the project root and automatically generates release PRs.