### PR TITLE
feat(ci): automate merging for release-please PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,3 +72,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Enable Auto-merge for Release PR
+        if: ${{ steps.release.outputs.pr }}
+        run: gh pr merge --auto --merge "${{ fromJson(steps.release.outputs.pr).number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a step to the `release-please` workflow that automatically enables auto-merge for PRs generated by the release bot. 

⚠️ **IMPORTANT:** You must enable "Allow auto-merge" in the repository settings (`Settings > General > Pull Requests`) for this to work.