### PR TITLE
fix(ci): provide repo flag to gh pr merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,6 @@ jobs:
 
       - name: Enable Auto-merge for Release PR
         if: ${{ steps.release.outputs.pr }}
-        run: gh pr merge --auto --merge "${{ fromJson(steps.release.outputs.pr).number }}"
+        run: gh pr merge --auto --merge "${{ fromJson(steps.release.outputs.pr).number }}" --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds the `--repo` flag to the `gh pr merge` command. 
Without this flag, the command fails with `fatal: not a git repository` because the `release-please` action operates in a workspace without checking out the `.git` directory. Passing the repo explicitly bypasses the need for local `.git` context.