### PR TITLE
fix(ci): disable auto-merge for release-please PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,5 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      - name: Enable Auto-merge for Release PR
-        if: ${{ steps.release.outputs.pr }}
-        run: gh pr merge --auto --merge "${{ fromJson(steps.release.outputs.pr).number }}" --repo ${{ github.repository }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # NOTE: Release PRs created by release-please must be merged MANUALLY by the repo owner.
+      # Auto-merge is intentionally disabled to avoid uncontrolled version bumps.


### PR DESCRIPTION
Remove the auto-merge step for release-please PRs.

Release PRs (created by the `release-please` bot) must now be merged **manually** by the repo owner. This gives full control over when a new version is published.

Regular feature/fix/docs PRs are unaffected.