### PR TITLE
fix(ci): skip release-please when commit is a release to prevent double version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,9 @@ jobs:
   release-please:
     name: Release Please PR Automation
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: |
+      github.ref == 'refs/heads/main' &&
+      !startsWith(github.event.head_commit.message, 'chore(main): release')
     steps:
       - uses: googleapis/release-please-action@v4
         id: release


### PR DESCRIPTION
## Problem
When merging a release PR (created by `release-please`), the push to `main` triggers the `release-please` workflow **again**. It re-reads the same commits and creates another release PR, causing double version bumps.

## Fix
Add a condition to the `release-please` job to **skip** if the triggering commit message starts with `chore(main): release` — which is exactly what release PRs use.

```yaml
if: |
  github.ref == 'refs/heads/main' &&
  !startsWith(github.event.head_commit.message, 'chore(main): release')
```

This ensures the bot only runs on real code changes, not on its own release commits.