### PR TITLE
fix(update): release plugin directory before replacement

### DIFF
--- a/update.ps1
+++ b/update.ps1
@@ -58,6 +58,9 @@ try {
     $ExtractedRootFolder = Get-ChildItem -Path $ExtractPath -Directory | Select-Object -First 1
 
     Write-Host "Removing old version..."
+    # The script is commonly launched from $InstallDir. Move out first so
+    # Windows does not keep the directory as the process working directory.
+    Set-Location -Path $TempDir
     Remove-Item -Path $InstallDir -Recurse -Force
 
     Write-Host "Installing new version to $InstallDir ..."
@@ -73,6 +76,8 @@ try {
     Write-Host "Update successful!" -ForegroundColor Green
     Write-Host "Plugin updated at: $InstallDir" -ForegroundColor Green
 } finally {
+    # Leave the temporary directory before deleting it.
+    Set-Location -Path ([System.IO.Path]::GetTempPath())
     if (Test-Path $TempDir) {
         Remove-Item -Path $TempDir -Recurse -Force
     }


### PR DESCRIPTION
## Summary of Changes

- Fix `Remove-Item` failure when the plugin directory is in use.
- Move the working directory to a temporary location before replacing the old version.
- Leave the temporary directory before cleanup.
- Ensure `update.ps1` works when run from the plugin directory.
- Validate PowerShell syntax.

## Type of Change

- [ ] 🚀 `feat`: New feature or SAST rule
- [ ] 🐛 `fix`: Bug fix
- [ ] 🛠️ `refactor`: Code refactoring without behavior change
- [ ] 📚 `docs`: Documentation update
- [ ] ⚙️ `ci`: CI/CD workflow change

## Verification Checklist

- [ ] All unit tests pass locally (`pytest`).
- [ ] Code passes Mypy strict type checking (`mypy --config-file=pyproject.toml control_plane.py src/`).
- [ ] Code formatted and linted via Ruff (`ruff check .`, `ruff format --check .`).
- [ ] Pylint score is 10.0/10.
- [ ] Follows Conventional Commits standards.
