### PR TITLE
fix(installer): remove GitHub CLI dependency from downloads

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1032,11 +1032,38 @@ def get_user_account(user_id):
       });
     }
 
+    function showCopyToast() {
+      const toast = document.getElementById('copy-toast');
+      toast.classList.remove('translate-y-4', 'opacity-0', 'pointer-events-none');
+      toast.classList.add('translate-y-0', 'opacity-100');
+      clearTimeout(window.copyToastTimer);
+      window.copyToastTimer = setTimeout(() => {
+        toast.classList.remove('translate-y-0', 'opacity-100');
+        toast.classList.add('translate-y-4', 'opacity-0', 'pointer-events-none');
+      }, 2200);
+    }
+
     function copySnippet(id) {
+      const button = event.currentTarget;
       navigator.clipboard.writeText(document.getElementById(id).innerText).then(() => {
-        alert("PowerShell snippet copied!");
+        const originalLabel = button.innerHTML;
+        button.innerHTML = '<i class="ph-bold ph-check"></i> Copied';
+        button.classList.add('!bg-brand-emerald', '!text-black');
+        showCopyToast();
+        setTimeout(() => {
+          button.innerHTML = originalLabel;
+          button.classList.remove('!bg-brand-emerald', '!text-black');
+        }, 1800);
       });
     }
   </script>
+
+  <div id="copy-toast" role="status" aria-live="polite"
+    class="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 translate-y-4 items-center gap-3 rounded-xl border-2 border-black bg-brand-emerald px-5 py-3 font-mono text-xs font-black text-black opacity-0 shadow-[5px_5px_0_#000] pointer-events-none transition-all duration-200">
+    <span class="flex h-6 w-6 items-center justify-center rounded-full border-2 border-black bg-black text-brand-emerald">
+      <i class="ph-bold ph-check text-xs"></i>
+    </span>
+    <span>PowerShell command copied</span>
+  </div>
 </body>
 </html>

--- a/install.ps1
+++ b/install.ps1
@@ -38,16 +38,19 @@ $ExtractPath = Join-Path $TempDir "extracted"
 
 try {
     Write-Progress -Activity "Installing Security SAST Guard" -Status "Downloading latest release" -PercentComplete 20
-    # Download zip and checksums using gh CLI (handles authentication automatically)
-    gh release download --repo "$RepoOwner/$RepoName" --pattern "*.zip" --dir $TempDir
-    gh release download --repo "$RepoOwner/$RepoName" --pattern "checksums.txt" --dir $TempDir
-    
-    # Get the downloaded zip file path
-    $ZipPath = (Get-ChildItem -Path $TempDir -Filter "*.zip" | Select-Object -First 1).FullName
+    $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$RepoOwner/$RepoName/releases/latest"
+    $ZipAsset = $Release.assets | Where-Object { $_.name -like "*.zip" } | Select-Object -First 1
+    $ChecksumAsset = $Release.assets | Where-Object { $_.name -eq "checksums.txt" } | Select-Object -First 1
+    if (-not $ZipAsset) { throw "No plugin ZIP asset found in the latest release." }
+    Write-Host "Found release: $($Release.tag_name)" -ForegroundColor Green
+    Invoke-WebRequest -Uri $ZipAsset.browser_download_url -OutFile (Join-Path $TempDir $ZipAsset.name)
+    if ($ChecksumAsset) { Invoke-WebRequest -Uri $ChecksumAsset.browser_download_url -OutFile (Join-Path $TempDir $ChecksumAsset.name) }
+    $ZipPath = Join-Path $TempDir $ZipAsset.name
     $ChecksumPath = Join-Path $TempDir "checksums.txt"
 
     if (Test-Path $ChecksumPath) {
         Write-Progress -Activity "Installing Security SAST Guard" -Status "Verifying package integrity" -PercentComplete 45
+        $ExpectedHashLine = Get-Content $ChecksumPath | Where-Object { $_ -match [regex]::Escape((Split-Path $ZipPath -Leaf)) } | Select-Object -First 1
         if ($ExpectedHashLine) {
             $ExpectedHash = ($ExpectedHashLine -split '\s+')[0].ToUpper()
             $ActualHash = (Get-FileHash -Path $ZipPath -Algorithm SHA256).Hash.ToUpper()

--- a/update.ps1
+++ b/update.ps1
@@ -48,16 +48,19 @@ if (Test-Path $ProfilePath) {
 Write-Host "Fetching latest release information using GitHub CLI..."
 try {
     Write-Progress -Activity "Updating Security SAST Guard" -Status "Downloading latest release" -PercentComplete 20
-    # Download zip and checksums using gh CLI (handles authentication automatically)
-    gh release download --repo "$RepoOwner/$RepoName" --pattern "*.zip" --dir $TempDir
-    gh release download --repo "$RepoOwner/$RepoName" --pattern "checksums.txt" --dir $TempDir
-    
-    # Get the downloaded zip file path
-    $ZipPath = (Get-ChildItem -Path $TempDir -Filter "*.zip" | Select-Object -First 1).FullName
+    $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$RepoOwner/$RepoName/releases/latest"
+    $ZipAsset = $Release.assets | Where-Object { $_.name -like "*.zip" } | Select-Object -First 1
+    $ChecksumAsset = $Release.assets | Where-Object { $_.name -eq "checksums.txt" } | Select-Object -First 1
+    if (-not $ZipAsset) { throw "No plugin ZIP asset found in the latest release." }
+    Write-Host "Found release: $($Release.tag_name)" -ForegroundColor Green
+    Invoke-WebRequest -Uri $ZipAsset.browser_download_url -OutFile (Join-Path $TempDir $ZipAsset.name)
+    if ($ChecksumAsset) { Invoke-WebRequest -Uri $ChecksumAsset.browser_download_url -OutFile (Join-Path $TempDir $ChecksumAsset.name) }
+    $ZipPath = Join-Path $TempDir $ZipAsset.name
     $ChecksumPath = Join-Path $TempDir "checksums.txt"
 
     if (Test-Path $ChecksumPath) {
         Write-Progress -Activity "Updating Security SAST Guard" -Status "Verifying package integrity" -PercentComplete 45
+        $ExpectedHashLine = Get-Content $ChecksumPath | Where-Object { $_ -match [regex]::Escape((Split-Path $ZipPath -Leaf)) } | Select-Object -First 1
         if ($ExpectedHashLine) {
             $ExpectedHash = ($ExpectedHashLine -split '\s+')[0].ToUpper()
             $ActualHash = (Get-FileHash -Path $ZipPath -Algorithm SHA256).Hash.ToUpper()


### PR DESCRIPTION
## Summary of Changes

- Replace `gh release download` with GitHub REST API requests.
- Allow installation and updates without GitHub CLI.
- Automatically detect the latest release ZIP and checksum assets.
- Verify the downloaded package checksum.
- Provide a clear error when no ZIP asset is available.

## Type of Change

- [ ] 🚀 `feat`: New feature or SAST rule
- [ ] 🐛 `fix`: Bug fix
- [ ] 🛠️ `refactor`: Code refactoring without behavior change
- [ ] 📚 `docs`: Documentation update
- [ ] ⚙️ `ci`: CI/CD workflow change

## Verification Checklist

- [ ] All unit tests pass locally (`pytest`).
- [ ] Code passes Mypy strict type checking (`mypy --config-file=pyproject.toml control_plane.py src/`).
- [ ] Code formatted and linted via Ruff (`ruff check .`, `ruff format --check .`).
- [ ] Pylint score is 10.0/10.
- [ ] Follows Conventional Commits standards.
