### PR TITLE
fix(mcp): resolve absolute python executable path in mcp_config

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -115,8 +115,11 @@ function Register-MCPServer {
         $JsonObj | Add-Member -NotePropertyName "mcpServers" -NotePropertyValue ([PSCustomObject]@{}) -Force
     }
 
+    $PyCmd = (Get-Command python -ErrorAction SilentlyContinue).Source
+    if ($PyCmd) { $PyCmd = $PyCmd.Replace("\", "/") } else { $PyCmd = "python" }
+
     $ServerConfig = [PSCustomObject]@{
-        command = "python"
+        command = $PyCmd
         args    = @("-m", "src.mcp.server")
         cwd     = $NormPath
         env     = [PSCustomObject]@{ PYTHONPATH = $NormPath }

--- a/update.ps1
+++ b/update.ps1
@@ -118,8 +118,11 @@ function Register-MCPServer {
         $JsonObj | Add-Member -NotePropertyName "mcpServers" -NotePropertyValue ([PSCustomObject]@{}) -Force
     }
 
+    $PyCmd = (Get-Command python -ErrorAction SilentlyContinue).Source
+    if ($PyCmd) { $PyCmd = $PyCmd.Replace("\", "/") } else { $PyCmd = "python" }
+
     $ServerConfig = [PSCustomObject]@{
-        command = "python"
+        command = $PyCmd
         args    = @("-m", "src.mcp.server")
         cwd     = $NormPath
         env     = [PSCustomObject]@{ PYTHONPATH = $NormPath }


### PR DESCRIPTION
## Summary of Changes
- Updated `Register-MCPServer` in `install.ps1` and `update.ps1` to dynamically resolve the absolute path to `python.exe` via `(Get-Command python).Source`.
- Ensures GUI applications on Windows (like Antigravity / Gemini CLI) can launch the `security-sast-guard` MCP server reliably without path resolution failures when running outside standard command shells.