### PR TITLE
fix(updater): stop active mcp process and use overlay copy to prevent file locks

### DIFF
--- a/remove.ps1
+++ b/remove.ps1
@@ -111,6 +111,14 @@ if ($Confirmation -notmatch "^[Yy]$") {
 try {
     Write-CyberStep -Step 1 -TotalSteps 1 -Message "Removing plugin files and configuration..." -Percent 50
     Set-Location -Path (Split-Path -Path $InstallDir -Parent)
+    
+    try {
+        Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*src.mcp.server*" -and $_.CommandLine -like "*security-sast-guard*" } | ForEach-Object {
+            Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+        }
+        Start-Sleep -Milliseconds 500
+    } catch {}
+
     Remove-Item -Path $InstallDir -Recurse -Force
     Write-CyberPass "Successfully uninstalled plugin files from system"
 

--- a/update.ps1
+++ b/update.ps1
@@ -212,9 +212,16 @@ try {
     Expand-Archive -Path $ZipPath -DestinationPath $ExtractPath -Force
     $ExtractedRootFolder = Get-ChildItem -Path $ExtractPath -Directory | Select-Object -First 1
 
-    Set-Location -Path $TempDir
-    Remove-Item -Path $InstallDir -Recurse -Force
-    Move-Item -Path $ExtractedRootFolder.FullName -Destination $InstallDir -Force
+    try {
+        Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*src.mcp.server*" -and $_.CommandLine -like "*security-sast-guard*" } | ForEach-Object {
+            Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+        }
+        Start-Sleep -Milliseconds 500
+    } catch {}
+
+    Get-ChildItem -Path $ExtractedRootFolder.FullName | ForEach-Object {
+        Copy-Item -Path $_.FullName -Destination $InstallDir -Recurse -Force
+    }
 
     if ($HasProfile) {
         Copy-Item -Path $BackupPath -Destination $ProfilePath -Force


### PR DESCRIPTION
## Summary of Changes
- Added automatic termination of active `src.mcp.server` processes in `update.ps1` and `remove.ps1` before file operations to release open file handles.
- Replaced `Remove-Item` on the target directory with overlay file copy (`Copy-Item -Recurse -Force`) during update step, preventing Windows `The process cannot access the file because it is being used by another process` errors.
- Tested with AST parser, pytest (62/62 passed), and pylint (10/10).