### PR TITLE
fix(scanner): support explicit single file scan for aspx and dot-net webforms

### DIFF
--- a/src/domain/ast_context_engine.py
+++ b/src/domain/ast_context_engine.py
@@ -28,11 +28,14 @@ class ASTContextEngine:
         _ = line_number
         stripped = line_content.strip()
 
+        lower_path = file_path.lower()
         # HTML / ASPX Inline Event & Attribute Detection
         if re.search(r"(?i)\bon[a-z]+\s*=", stripped):
             return "html-inline-event"
         if (
-            file_path.endswith((".html", ".htm", ".aspx", ".ascx"))
+            lower_path.endswith(
+                (".html", ".htm", ".aspx", ".ascx", ".master", ".ashx", ".asmx")
+            )
             and "<" in stripped
             and ">" in stripped
             and "=" in stripped
@@ -40,14 +43,18 @@ class ASTContextEngine:
             return "html-attribute"
 
         # JS / TS RegExp method vs Dangerous Sink Detection
-        if file_path.endswith((".js", ".ts", ".jsx", ".tsx", ".aspx", ".html")) and (
+        if lower_path.endswith(
+            (".js", ".ts", ".jsx", ".tsx", ".aspx", ".ascx", ".html")
+        ) and (
             re.search(r"\.[a-zA-Z0-9_$]+\.exec\s*\(", stripped)
             or "filenameRegex.exec" in stripped
         ):
             return "client-js-regex"
 
         # Server-side Backend Code Scope
-        if file_path.endswith((".py", ".cs", ".java", ".php", ".rb")):
+        if lower_path.endswith(
+            (".py", ".cs", ".java", ".php", ".rb", ".aspx", ".ascx", ".ashx")
+        ):
             return "server-code"
 
         return "global"

--- a/src/domain/sast_scanner.py
+++ b/src/domain/sast_scanner.py
@@ -289,7 +289,12 @@ class SASTScanner:
                         files_to_scan.append(file_p)
 
         for file_path in files_to_scan:
-            if target_path.is_file() and ignore_filter.should_ignore(file_path):
+            # Explicit single file targets bypass default extension/path ignore rules
+            if (
+                target_path.is_file()
+                and target_path != file_path
+                and ignore_filter.should_ignore(file_path)
+            ):
                 ignored_files += 1
                 continue
 

--- a/tests/test_sast.py
+++ b/tests/test_sast.py
@@ -72,3 +72,17 @@ def test_aspnet_false_positive_filtering(tmp_path: Path) -> None:
     # Lines 1 & 2 should be filtered out as false positives
     lines = [r["line"] for r in results]
     assert lines == [3]
+
+
+def test_single_file_scan_unignored_even_if_default_ignored(tmp_path: Path) -> None:
+    # Create an .aspx file inside a folder named 'docs' (which is default ignored)
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    test_file = docs_dir / "ExamDetail.aspx"
+    test_file.write_text('<input onfocus="eval(location.hash)">\n')
+
+    scanner = SASTScanner()
+    res = scanner.scan_with_metadata(str(test_file))
+
+    assert res["metadata"]["scanned_files"] == 1
+    assert len(res["findings"]) == 1


### PR DESCRIPTION
## Fix Summary

This PR resolves an issue where scanning explicit single file targets (such as `.aspx`, `.ascx`, `.master`, `.ashx`, `.asmx` or files located in folders matching default ignore directory patterns like `docs/`) resulted in `Scanned 0 files`.

### Changes:
1. **Explicit Single File Target Un-ignore:**
   - Modified `scan_with_metadata()` in `src/domain/sast_scanner.py` to ensure explicit single file targets (`target_path.is_file()`) bypass default `ignore_filter` rules.
2. **Enhanced ASP.NET WebForms Scope Support:**
   - Extended `ASTContextEngine` in `src/domain/ast_context_engine.py` to handle case-insensitive `.aspx`, `.ascx`, `.master`, `.ashx`, and `.asmx` extensions for `html-attribute` and `server-code` scope resolution.
3. **Unit Tests:**
   - Added `test_single_file_scan_unignored_even_if_default_ignored` in `tests/test_sast.py`.

### Quality Gate Verification:
- **Pytest:** 85/85 tests passed.
- **Pylint Score:** 10.00/10.
- **Ruff Linter & Formatter:** Clean.