### PR TITLE
refactor(core): decouple report generation to allow AI analysis injection

### DIFF
--- a/skills/sast-audit/SKILL.md
+++ b/skills/sast-audit/SKILL.md
@@ -17,6 +17,11 @@ Interactive Grill UI Workflow:
 
 Execution:
 - The active audit level (`lite`, `full`, `ultra`) MUST be retrieved from `profile.json` / `sast_get_status` rather than asking the user again.
-- `file` / `diff` type: Call Native MCP tool `sast_scan_file` or `sast_scan_diff` when available. If fallback to `run_command` is required, specify `toolAction="Scanning File Security"` and `toolSummary="SAST Security Audit"`.
-- `codebase` / large audit: Run silently as background task (`run_command` async with `toolAction="Auditing Codebase Security"` and `toolSummary="Codebase SAST Audit"`), inform task ID, monitor status, and output concise report upon completion.
+- `file` / `diff` type: Call Native MCP tool `sast_scan_file` or `sast_scan_diff` when available. 
+- `codebase` / large audit: Run silently as background task (`run_command` async with `toolAction="Auditing Codebase Security"` and `toolSummary="Codebase SAST Audit"`).
+- **CRITICAL - AI Analysis Step**: After receiving the raw JSON findings from the scan tools, you (the AI Agent) MUST:
+  1. Analyze the JSON findings intelligently.
+  2. Write a concise, Markdown-formatted analysis (e.g., summarizing key risks, filtering obvious false positives, and proposing architectural mitigations).
+  3. Call the `sast_generate_report` MCP tool, passing the original `findings`, `target_path`, and your `ai_analysis`. This will embed your analysis directly into the final Markdown report.
+  4. Return the path of the generated report to the user.
 

--- a/src/application/audit_service.py
+++ b/src/application/audit_service.py
@@ -54,7 +54,7 @@ class AuditService:
         return self.profile
 
     def run_audit(
-        self, target_path: str, verbose: bool = False
+        self, target_path: str, verbose: bool = False, generate_report: bool = True
     ) -> tuple[list[dict[str, Any]], str, str]:
         """Execute SAST audit on target path and return findings and report."""
         self._reload_profile()
@@ -62,6 +62,15 @@ class AuditService:
         findings = res["findings"]
         metadata = res["metadata"]
         audit_level = self.profile.get("audit_level", "full")
+
+        if not generate_report:
+            scanned = metadata.get("scanned_files", 0)
+            dur = metadata.get("duration_seconds", 0)
+            summary = (
+                f"Scan complete. {len(findings)} findings in {scanned} files ({dur}s)."
+            )
+            return findings, "", summary
+
         report_md, summary = generate_markdown_report(
             findings,
             target_path=target_path,

--- a/src/domain/ignore_filter.py
+++ b/src/domain/ignore_filter.py
@@ -47,9 +47,9 @@ DEFAULT_IGNORE_DIRS: set[str] = {
     "Upload",
     "uploads",
     "upload",
-    "Images",   # Static image assets directory
+    "Images",  # Static image assets directory
     "images",
-    "Template", # HTML / email / doc templates directory
+    "Template",  # HTML / email / doc templates directory
     "template",
     "TestResults",  # .NET / MSTest test execution results
     ".next",

--- a/src/infrastructure/report_generator.py
+++ b/src/infrastructure/report_generator.py
@@ -161,6 +161,7 @@ def _substitute_placeholders(
     counts: dict[str, int],
     metadata: dict[str, Any] | None = None,
     audit_level: str = "full",
+    ai_analysis: str | None = None,
 ) -> str:
     meta = metadata or {}
     scanned_files = meta.get("scanned_files", "N/A")
@@ -206,9 +207,13 @@ def _substitute_placeholders(
         content = content.replace(key, val)
 
     if "## 🔍 Detailed Findings" in content:
+        if ai_analysis:
+            ai_block = f"## 🤖 AI Security Analysis\n\n{ai_analysis}\n\n---\n\n"
+        else:
+            ai_block = ""
         content = content.replace(
             "## 🔍 Detailed Findings",
-            f"{metadata_block}\n---\n\n## 🔍 Detailed Findings",
+            f"{metadata_block}\n---\n\n{ai_block}## 🔍 Detailed Findings",
         )
     return content
 
@@ -221,6 +226,7 @@ def generate_markdown_report(
     template_path: str | Path | None = None,
     metadata: dict[str, Any] | None = None,
     audit_level: str = "full",
+    ai_analysis: str | None = None,
 ) -> tuple[str, str]:
     """Generate Markdown report file for SAST findings using template."""
     counts = _count_severities(findings)
@@ -238,7 +244,8 @@ def generate_markdown_report(
             f"SAST Audit completed.{scanned_str} Total: 0 findings "
             "(Critical: 0, High: 0, Medium: 0, Low: 0)."
         )
-        return "", summary
+        if not ai_analysis:
+            return "", summary
 
     target_dir = Path(output_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
@@ -254,7 +261,13 @@ def generate_markdown_report(
     )
 
     report_content = _substitute_placeholders(
-        template_content, target_path, findings, counts, metadata, audit_level
+        template_content,
+        target_path,
+        findings,
+        counts,
+        metadata,
+        audit_level,
+        ai_analysis,
     )
     report_file.write_text(report_content, encoding="utf-8")
 

--- a/src/mcp/schemas.py
+++ b/src/mcp/schemas.py
@@ -167,4 +167,27 @@ TOOLS_SCHEMAS: list[dict[str, Any]] = [
             "required": ["file_path", "line_number"],
         },
     },
+    {
+        "name": "sast_generate_report",
+        "description": "Generate SAST markdown report containing AI analysis.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "findings": {
+                    "type": "array",
+                    "description": "JSON findings returned from the scanner.",
+                    "items": {"type": "object"},
+                },
+                "target_path": {
+                    "type": "string",
+                    "description": "Path that was scanned.",
+                },
+                "ai_analysis": {
+                    "type": "string",
+                    "description": "AI's markdown analysis of the findings.",
+                },
+            },
+            "required": ["findings", "target_path", "ai_analysis"],
+        },
+    },
 ]

--- a/src/mcp/server.py
+++ b/src/mcp/server.py
@@ -133,6 +133,12 @@ class MCPServer:
             )
         if tool_name == "sast_set_mode":
             return self.handlers.handle_sast_set_mode(args.get("mode", "strict"))
+        if tool_name == "sast_generate_report":
+            return self.handlers.handle_sast_generate_report(
+                args.get("findings", []),
+                args.get("target_path", "."),
+                args.get("ai_analysis", ""),
+            )
 
         return {"error": f"Unknown tool name: {tool_name}"}
 

--- a/src/mcp/tools.py
+++ b/src/mcp/tools.py
@@ -20,8 +20,8 @@ class MCPToolHandlers:
 
     def handle_sast_scan_file(self, file_path: str) -> dict[str, Any]:
         """Scan a single file and include taint traces in output."""
-        findings, report_file, summary = self.audit_service.run_audit(
-            target_path=file_path
+        findings, _, summary = self.audit_service.run_audit(
+            target_path=file_path, generate_report=False
         )
         taint_findings = self.audit_service.run_taint_analysis(file_path)
         taint_traces = [
@@ -46,7 +46,6 @@ class MCPToolHandlers:
         ]
         return {
             "status": "success",
-            "report_file": str(report_file),
             "findings_count": len(findings),
             "summary": summary,
             "findings": [
@@ -65,7 +64,9 @@ class MCPToolHandlers:
 
     def handle_sast_scan_diff(self) -> dict[str, Any]:
         """Scan modified git files and include taint traces in output."""
-        findings, report_file, summary = self.audit_service.run_audit(target_path=".")
+        findings, _, summary = self.audit_service.run_audit(
+            target_path=".", generate_report=False
+        )
         taint_findings = self.audit_service.run_taint_analysis(".")
         taint_traces = [
             {
@@ -89,10 +90,45 @@ class MCPToolHandlers:
         ]
         return {
             "status": "success",
-            "report_file": str(report_file),
             "findings_count": len(findings),
             "summary": summary,
             "taint_traces": taint_traces,
+            "findings": [
+                {
+                    "rule_id": f.get("rule_id", ""),
+                    "rule_name": f.get("rule_name", ""),
+                    "severity": f.get("severity", ""),
+                    "file_path": f.get("path", ""),
+                    "line_number": f.get("line", 0),
+                    "action": f.get("action", "Block"),
+                }
+                for f in findings
+            ],
+        }
+
+    def handle_sast_generate_report(
+        self, findings: list[dict[str, Any]], target_path: str, ai_analysis: str
+    ) -> dict[str, Any]:
+        """Generate a SAST markdown report containing AI analysis."""
+        # pylint: disable=import-outside-toplevel
+        from src.infrastructure.report_generator import generate_markdown_report
+
+        metadata = {
+            "scanned_files": "N/A",
+            "total_lines": "N/A",
+            "duration_seconds": "N/A",
+        }
+        report_file, summary = generate_markdown_report(
+            findings,
+            target_path=target_path,
+            metadata=metadata,
+            audit_level=self.profile_loader.load().get("audit_level", "full"),
+            ai_analysis=ai_analysis,
+        )
+        return {
+            "status": "success",
+            "report_file": str(report_file),
+            "summary": summary,
         }
 
     def handle_sast_check_command(self, command: str) -> dict[str, Any]:


### PR DESCRIPTION
Decouple the SAST scan and report generation processes to allow the AI Agent to analyze the JSON findings intelligently and embed the analysis into the final Markdown report.

Changes:
- Added `generate_report` flag to `AuditService.run_audit`.
- Updated `generate_markdown_report` to accept an `ai_analysis` parameter.
- Created `sast_generate_report` MCP tool.
- Updated Agent directives in `SKILL.md`.