### PR TITLE
fix(scanner): fix multi-file incremental git diff scanning

### DIFF
--- a/src/application/audit_service.py
+++ b/src/application/audit_service.py
@@ -67,11 +67,15 @@ class AuditService:
         sarif_output_path: str | None = None,
         html_output_path: str | None = None,
         threads: int | None = None,
+        incremental: bool = False,
     ) -> tuple[list[dict[str, Any]], str, str]:
         """Execute SAST audit on target path and return findings and report."""
         self._reload_profile()
         res = self.scanner.scan_with_metadata(
-            target_path, verbose=verbose, threads=threads
+            target_path,
+            verbose=verbose,
+            threads=threads,
+            incremental=incremental,
         )
         findings = res["findings"]
         metadata = res["metadata"]

--- a/src/cli/dispatcher.py
+++ b/src/cli/dispatcher.py
@@ -131,6 +131,7 @@ def _handle_scan(args: list[str]) -> int:
     output_format = "markdown"
     target_level: str | None = None
     threads: int | None = None
+    incremental = False
     positional_args: list[str] = []
 
     idx = 0
@@ -138,6 +139,9 @@ def _handle_scan(args: list[str]) -> int:
         arg = args[idx]
         if arg in ("-v", "--verbose"):
             verbose = True
+            idx += 1
+        elif arg in ("--diff", "-d"):
+            incremental = True
             idx += 1
         elif arg == "--sarif":
             output_format = "sarif"
@@ -181,6 +185,9 @@ def _handle_scan(args: list[str]) -> int:
     target_path = positional_args[0] if positional_args else "."
     if target_path.lower() == "codebase":
         target_path = "."
+    elif target_path.lower() == "diff":
+        incremental = True
+        target_path = "."
 
     service = AuditService()
     if target_level:
@@ -193,6 +200,7 @@ def _handle_scan(args: list[str]) -> int:
         sarif_output_path=sarif_output_path,
         html_output_path=html_output_path,
         threads=threads,
+        incremental=incremental,
     )
     print(summary)
     return 0

--- a/src/domain/git_helper.py
+++ b/src/domain/git_helper.py
@@ -25,25 +25,60 @@ class GitHelper:
             return False
 
     @staticmethod
-    def get_changed_files(path: Path | str) -> list[Path]:
+    def get_repo_root(path: Path | str) -> Path | None:
+        """Get repository root directory Path."""
+        p = Path(path).resolve()
+        target_dir = p if p.is_dir() else p.parent
+        try:
+            res = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],  # noqa: S607
+                cwd=str(target_dir),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if res.returncode == 0 and res.stdout.strip():
+                return Path(res.stdout.strip()).resolve()
+            return None
+        except (OSError, ValueError):
+            return None
+
+    @staticmethod
+    def _is_file_in_target(target: Path, candidate: Path) -> bool:
+        """Check if candidate file matches or resides inside target path."""
+        if not candidate.is_file():
+            return False
+        if target.is_file():
+            return candidate == target
+        if target.is_dir():
+            return candidate == target or target in candidate.parents
+        return True
+
+    @staticmethod
+    def get_changed_files(path: Path | str, base_ref: str | None = None) -> list[Path]:
         """Get list of modified, staged, or untracked files in git repository."""
         p = Path(path).resolve()
         target_dir = p if p.is_dir() else p.parent
         if not GitHelper.is_git_repo(target_dir):
             return []
 
+        repo_root = GitHelper.get_repo_root(target_dir) or target_dir
+        diff_base = base_ref or GitHelper.get_diff_base(target_dir)
+
         changed_files: set[Path] = set()
 
-        # 1. Get modified & staged files via git diff
-        for cmd in [
+        diff_commands = [
+            ["git", "diff", "--name-only", diff_base],
             ["git", "diff", "--name-only", "HEAD"],
             ["git", "diff", "--name-only", "--cached"],
             ["git", "ls-files", "--others", "--exclude-standard"],
-        ]:
+        ]
+
+        for cmd in diff_commands:
             try:
                 res = subprocess.run(  # noqa: S603
                     cmd,
-                    cwd=str(target_dir),
+                    cwd=str(repo_root),
                     capture_output=True,
                     text=True,
                     check=False,
@@ -54,13 +89,13 @@ class GitHelper:
                     rel_path = line.strip()
                     if not rel_path:
                         continue
-                    full_path = (target_dir / rel_path).resolve()
-                    if full_path.is_file():
+                    full_path = (repo_root / rel_path).resolve()
+                    if GitHelper._is_file_in_target(p, full_path):
                         changed_files.add(full_path)
             except (OSError, ValueError):
                 continue
 
-        return list(changed_files)
+        return sorted(changed_files, key=str)
 
     @staticmethod
     def get_diff_base(path: Path | str) -> str:

--- a/src/domain/sast_scanner.py
+++ b/src/domain/sast_scanner.py
@@ -319,13 +319,13 @@ class SASTScanner:
         files_to_scan: list[Path] = []
         is_incremental = False
 
-        if target_path.is_file():
-            files_to_scan = [target_path]
-        elif incremental and GitHelper.is_git_repo(target_path):
+        if incremental and GitHelper.is_git_repo(target_path):
             git_files = GitHelper.get_changed_files(target_path)
             if git_files:
                 is_incremental = True
                 files_to_scan = git_files
+        elif target_path.is_file():
+            files_to_scan = [target_path]
 
         if not files_to_scan and target_path.is_dir():
             # Perform top-down os.walk with early directory pruning
@@ -342,11 +342,7 @@ class SASTScanner:
 
         valid_files: list[Path] = []
         for file_path in files_to_scan:
-            if (
-                target_path.is_file()
-                and target_path != file_path
-                and ignore_filter.should_ignore(file_path)
-            ):
+            if not target_path.is_file() and ignore_filter.should_ignore(file_path):
                 ignored_files += 1
             else:
                 valid_files.append(file_path)

--- a/src/mcp/tools.py
+++ b/src/mcp/tools.py
@@ -65,7 +65,7 @@ class MCPToolHandlers:
     def handle_sast_scan_diff(self) -> dict[str, Any]:
         """Scan modified git files and include taint traces in output."""
         findings, _, summary = self.audit_service.run_audit(
-            target_path=".", generate_report=False
+            target_path=".", generate_report=False, incremental=True
         )
         taint_findings = self.audit_service.run_taint_analysis(".")
         taint_traces = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,18 @@ def test_dispatcher_scan_command(capsys: CaptureFixture[str], tmp_path) -> None:
     assert "Detailed report saved to:" in captured.out
 
 
+def test_dispatcher_scan_diff_command(capsys: CaptureFixture[str]) -> None:
+    code = main(["scan", "--diff"])
+    assert code == 0
+    captured = capsys.readouterr()
+    assert "SAST Audit completed." in captured.out
+
+    code_diff_pos = main(["scan", "diff"])
+    assert code_diff_pos == 0
+    captured_diff_pos = capsys.readouterr()
+    assert "SAST Audit completed." in captured_diff_pos.out
+
+
 def test_dispatcher_level_command(capsys: CaptureFixture[str]) -> None:
     code = main(["level"])
     assert code == 0

--- a/tests/test_git_helper.py
+++ b/tests/test_git_helper.py
@@ -32,24 +32,91 @@ def test_get_changed_files_not_git_repo(tmp_path: Path) -> None:
         assert not GitHelper.get_changed_files(tmp_path)
 
 
+def test_get_repo_root_success(tmp_path: Path) -> None:
+    """Test get_repo_root returns Path when rev-parse succeeds."""
+    mock_res = MagicMock(returncode=0, stdout=f"{tmp_path}\n")
+    with patch("subprocess.run", return_value=mock_res):
+        root = GitHelper.get_repo_root(tmp_path)
+        assert root == tmp_path.resolve()
+
+
+def test_get_repo_root_failure(tmp_path: Path) -> None:
+    """Test get_repo_root returns None when rev-parse fails."""
+    mock_res = MagicMock(returncode=128, stdout="")
+    with patch("subprocess.run", return_value=mock_res):
+        root = GitHelper.get_repo_root(tmp_path)
+        assert root is None
+
+
 def test_get_changed_files_success(tmp_path: Path) -> None:
     """Test get_changed_files collecting modified files."""
     test_file = tmp_path / "modified.py"
     test_file.write_text("print('hello')", encoding="utf-8")
 
-    mock_diff_head = MagicMock(returncode=0, stdout="modified.py\n")
+    mock_rev_parse = MagicMock(returncode=0, stdout=f"{tmp_path}\n")
+    mock_diff_base = MagicMock(returncode=0, stdout="modified.py\n")
+    mock_diff_head = MagicMock(returncode=0, stdout="")
     mock_diff_cached = MagicMock(returncode=0, stdout="")
     mock_ls_files = MagicMock(returncode=0, stdout="")
 
     with (
         patch.object(GitHelper, "is_git_repo", return_value=True),
+        patch.object(GitHelper, "get_diff_base", return_value="origin/main"),
         patch(
             "subprocess.run",
-            side_effect=[mock_diff_head, mock_diff_cached, mock_ls_files],
+            side_effect=[
+                mock_rev_parse,
+                mock_diff_base,
+                mock_diff_head,
+                mock_diff_cached,
+                mock_ls_files,
+            ],
         ),
     ):
         changed = GitHelper.get_changed_files(tmp_path)
         assert test_file in changed
+
+
+def test_get_changed_files_multiple_files_and_subdirectories(tmp_path: Path) -> None:
+    """Test get_changed_files collecting multiple modified, staged,
+    and untracked files.
+    """
+    file1 = tmp_path / "src" / "app.py"
+    file1.parent.mkdir(parents=True, exist_ok=True)
+    file1.write_text("print('app')", encoding="utf-8")
+
+    file2 = tmp_path / "tests" / "test_app.py"
+    file2.parent.mkdir(parents=True, exist_ok=True)
+    file2.write_text("print('test')", encoding="utf-8")
+
+    file3 = tmp_path / "README.md"
+    file3.write_text("# Readme", encoding="utf-8")
+
+    mock_rev_parse = MagicMock(returncode=0, stdout=f"{tmp_path}\n")
+    mock_diff_base = MagicMock(returncode=0, stdout="src/app.py\n")
+    mock_diff_head = MagicMock(returncode=0, stdout="")
+    mock_diff_cached = MagicMock(returncode=0, stdout="tests/test_app.py\n")
+    mock_ls_files = MagicMock(returncode=0, stdout="README.md\n")
+
+    with (
+        patch.object(GitHelper, "is_git_repo", return_value=True),
+        patch.object(GitHelper, "get_diff_base", return_value="origin/main"),
+        patch(
+            "subprocess.run",
+            side_effect=[
+                mock_rev_parse,
+                mock_diff_base,
+                mock_diff_head,
+                mock_diff_cached,
+                mock_ls_files,
+            ],
+        ),
+    ):
+        changed = GitHelper.get_changed_files(tmp_path)
+        assert len(changed) == 3
+        assert file1 in changed
+        assert file2 in changed
+        assert file3 in changed
 
 
 def test_get_diff_base_not_git_repo(tmp_path: Path) -> None:

--- a/tests/test_mcp_scan_taint_output.py
+++ b/tests/test_mcp_scan_taint_output.py
@@ -40,9 +40,12 @@ def test_scan_diff_includes_taint_traces():
     with (
         patch.object(
             handlers.audit_service, "run_audit", return_value=([], "", "0 findings")
-        ),
+        ) as mock_run_audit,
         patch.object(handlers.audit_service, "run_taint_analysis", return_value=[]),
     ):
         result = handlers.handle_sast_scan_diff()
+        mock_run_audit.assert_called_once_with(
+            target_path=".", generate_report=False, incremental=True
+        )
     assert "taint_traces" in result
     assert result["taint_traces"] == []


### PR DESCRIPTION
## Summary of Changes

Closes #160

### Root Cause
1. `MCPToolHandlers.handle_sast_scan_diff()` was calling `run_audit()` without passing `incremental=True`, defaulting to a full codebase scan or single fallback.
2. `GitHelper.get_changed_files()` was resolving relative paths against the target subdirectory instead of the git repository toplevel root (`git rev-parse --show-toplevel`), causing path resolution failure when called from subdirectories.
3. `GitHelper.get_changed_files()` was only running `git diff HEAD`, ignoring changes committed on development branches compared to the base branch (`origin/main`, `origin/master`).
4. `SASTScanner.scan_with_metadata()` checked `if target_path.is_file():` before `elif incremental:`, hardcoding scans to 1 file even when incremental diff mode was requested.
5. CLI `control_plane.py scan` did not handle `--diff` / `-d` flags or the `diff` positional keyword.

### Key Changes
- **`src/domain/git_helper.py`**: Added `get_repo_root()`, updated `get_changed_files()` to resolve from repo root and combine `diff_base`, staged (`--cached`), and untracked (`--others`) files. Extracted `_is_file_in_target()` helper for cleaner control flow.
- **`src/domain/sast_scanner.py`**: Prioritized incremental diff mode in `scan_with_metadata()` and ensured consistent `IgnoreFilter` application.
- **`src/application/audit_service.py`**: Added `incremental: bool = False` parameter to `run_audit()`.
- **`src/mcp/tools.py`**: Updated `handle_sast_scan_diff()` to pass `incremental=True`.
- **`src/cli/dispatcher.py`**: Added support for `--diff` / `-d` and `diff` positional target.
- **Unit Tests**: Added tests in `tests/test_git_helper.py`, `tests/test_mcp_scan_taint_output.py`, and `tests/test_cli.py`.

### Verification & CI Quality Gate
- `ruff check .`: Passed
- `ruff format --check .`: Passed (132 files formatted)
- `pylint control_plane.py src/`: 10.00/10
- `mypy control_plane.py src/`: 0 issues across 55 files
- `pytest`: 301/301 passed (100% pass rate)
