### PR TITLE
chore(ci): remove missing dependencies label from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
+
 


### PR DESCRIPTION
## Summary of Changes

Fixes Dependabot configuration error:
> "The following labels could not be found: dependencies. Please create it before Dependabot can add it to a pull request."

- Removed `labels: - "dependencies"` requirement from `.github/dependabot.yml` for both `pip` and `github-actions` ecosystems.
- Dependabot can now create and manage dependency pull requests without requiring the `dependencies` label to be manually created first.
